### PR TITLE
Load AppConfig subclass

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings.py
@@ -13,4 +13,4 @@ class DevelopmentConfiguration(DevelopmentBaseConfiguration):
 
     @staticmethod
     def before_binding(configuration: DevelopmentConfiguration) -> None:
-        configuration.INSTALLED_APPS += ['{{ cookiecutter.pkg_name }}.{{ cookiecutter.first_app_name }}']
+        configuration.INSTALLED_APPS += ['{{ cookiecutter.pkg_name }}.{{ cookiecutter.first_app_name }}.apps.{{ cookiecutter.first_app_name.capitalize() }}Config']

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/apps.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/apps.py
@@ -2,5 +2,5 @@ from django.apps import AppConfig
 
 
 class {{ cookiecutter.first_app_name.capitalize() }}Config(AppConfig):
-    name = '{{ cookiecutter.first_app_name }}'
-    verbose_name = '{{ cookiecutter.project_name }}: {{ cookiecutter.first_app_name }}'
+    name = '{{ cookiecutter.pkg_name }}.{{ cookiecutter.first_app_name }}'
+    verbose_name = '{{ cookiecutter.project_name }}: {{ cookiecutter.first_app_name.capitalize() }}'


### PR DESCRIPTION
Without this, Django creates its own default AppConfig for the app.